### PR TITLE
Removed Ruby's ? char literal

### DIFF
--- a/Crystal.tmLanguage
+++ b/Crystal.tmLanguage
@@ -1629,37 +1629,6 @@
 			<string>comment.line.number-sign.crystal</string>
 		</dict>
 		<dict>
-			<key>comment</key>
-			<string>
-			matches questionmark-letters.
-
-			examples (1st alternation = hex):
-			?\x1     ?\x61
-
-			examples (2nd alternation = octal):
-			?\0      ?\07     ?\017
-
-			examples (3rd alternation = escaped):
-			?\n      ?\b
-
-			examples (4th alternation = meta-ctrl):
-			?\C-a    ?\M-a    ?\C-\M-\C-\M-a
-
-			examples (4th alternation = normal):
-			?a       ?A       ?0
-			?*       ?"       ?(
-			?.       ?#
-
-
-			the negative lookbehind prevents against matching
-			p(42.tainted?)
-			</string>
-			<key>match</key>
-			<string>(?&lt;!\w)\?(\\(x\h{1,2}(?!\h)\b|0[0-7]{0,2}(?![0-7])\b|[^x0MC])|(\\[MC]-)+\w|[^\s\\])</string>
-			<key>name</key>
-			<string>constant.numeric.crystal</string>
-		</dict>
-		<dict>
 			<key>begin</key>
 			<string>^__END__\n</string>
 			<key>captures</key>


### PR DESCRIPTION
It's erroneously colored in places like ```array[5]?.class``` and it doesn't work on Crystal anyway.